### PR TITLE
Remove redundant instruction

### DIFF
--- a/tutorials/getting-started/getting-started.md
+++ b/tutorials/getting-started/getting-started.md
@@ -165,8 +165,6 @@ mkdir data
 cp local.example.js data/local.js
 ```
 
-Edit the new `local.js` to remove or comment out the `uri` property.
-
 
 ##### Create the Database
 


### PR DESCRIPTION
deleted instruction to remove or comment out ‘uri’ property as it is already commented out.

![example_image](https://cloud.githubusercontent.com/assets/13784696/13157555/6f06407a-d680-11e5-9e87-49f69940d02d.jpg)
