### PR TITLE
Added next links on index pages

### DIFF
--- a/_layouts/reference.html
+++ b/_layouts/reference.html
@@ -21,7 +21,11 @@
     <div class="wrap main">
       {% block topOfContent %}{% endblock %}
       {{ content }}
-      {% block bottomOfContent %}{% endblock %}
+      {% block bottomOfContent %}
+        {% if next %}
+          <p class="next-article"><a href="{{ root }}{{ next.url }}">Next: {{ next.title | e }} &rarr;</a></p>
+        {% endif %}
+      {% endblock %}
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
Tutorial index pages did not have a link to move user to the next section, making it confusing where to go once you select your tutorial level. 

I added links to these pages by editing reference.html to include the same code as tutorial.html to pull in links to the next pages. 