### PR TITLE
Update broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Apostrophe Documentation
 
 This project contains [the documentation site](http://apostrophecms.org/docs/index.html) for [Apostrophe](http://apostrophecms.org/).
 
-You don't need to read this page just to read the documentation! [Read the actual documentation here.](index.html) This page is about *contributing* to the documentation.
+You don't need to read this page just to read the documentation! [Read the actual documentation here.](http://apostrophecms.org/docs/tutorials/index.html) This page is about *contributing* to the documentation.
 
 Building the docs
 -----------------

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Apostrophe Documentation
 
 This project contains [the documentation site](http://apostrophecms.org/docs/index.html) for [Apostrophe](http://apostrophecms.org/).
 
-You don't need to read this page just to read the documentation! [Read the actual documentation here.](http://apostrophecms.org/docs/tutorials/index.html) This page is about *contributing* to the documentation.
+You don't need to read this page just to read the documentation! [Read the actual documentation here.](http://apostrophecms.org/docs/) This page is about *contributing* to the documentation.
 
 Building the docs
 -----------------


### PR DESCRIPTION
The link where it says "Read the actual documentation here" goes to 404. Just updated the link to go to the start of the Docs.