### PR TITLE
apostrophe-cli uses create-project instead of create

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -25,7 +25,7 @@
       <h3>You can start building with Apostrophe right now.</h3>
       <code>
         <div><span class="red">$</span> npm install apostrophe-cli -g</div>
-        <div><span class="red">$</span> apostrophe create &lt;project-name&gt;</div>
+        <div><span class="red">$</span> apostrophe create-project &lt;project-name&gt;</div>
       </code>
       <p>Get up and running in fifteen minutes with our <a href="docs/tutorials/getting-started/index.html">Getting Started</a> tutorial.</p>
     </div>

--- a/docs/tutorials/getting-started/creating-your-first-project.md
+++ b/docs/tutorials/getting-started/creating-your-first-project.md
@@ -20,7 +20,7 @@ Now you can use it to create a new project.
 
 ```bash
 # Create a project
-apostrophe create test-project
+apostrophe create-project test-project
 ```
 
 **Important: rather than `test-project`, use your own project's "short name" containing only letters, digits, hyphens and/or underscores. It will be used by default as a MongoDB database name and a basis for cookie names, etc.** (Hyphens seem more popular than underscores for such purposes.)


### PR DESCRIPTION
`apostrophe create test-project` fails when creating new project. Updated to use `apostrophe-cli create-project`

```
$ apostrophe create test-project
 
 Apostrophe  create  Running the task [1/1]
 
 Apostrophe  Unable to locate an app.js in this directory. You need to be in the root directory of an Apostrophe project to run this command.  Failed
```