### PR TITLE
Updated so that create is now create-project

### DIFF
--- a/docs/tutorials/getting-started/creating-your-first-project.md
+++ b/docs/tutorials/getting-started/creating-your-first-project.md
@@ -20,7 +20,7 @@ Now you can use it to create a new project.
 
 ```bash
 # Create a project
-apostrophe create test-project
+apostrophe create-project test-project
 ```
 
 **Important: rather than `test-project`, use your own project's "short name" containing only letters, digits, hyphens and/or underscores. It will be used by default as a MongoDB database name and a basis for cookie names, etc.** (Hyphens seem more popular than underscores for such purposes.)


### PR DESCRIPTION
When I tried to run "create test-project" I got an error "Unable to locate an app.js in this directory." I checked the apostrophe help and "create" wasn't a command, but "create-project" was. I tried "create-project" and it worked, so it looks like that command was updated but this doc wasn't.