### PR TITLE
Updating docs to use the new create-project command of the CLI.

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -25,7 +25,7 @@
       <h3>You can start building with Apostrophe right now.</h3>
       <code>
         <div><span class="red">$</span> npm install apostrophe-cli -g</div>
-        <div><span class="red">$</span> apostrophe create &lt;project-name&gt;</div>
+        <div><span class="red">$</span> apostrophe create-project &lt;project-name&gt;</div>
       </code>
       <p>Get up and running in fifteen minutes with our <a href="docs/tutorials/getting-started/index.html">Getting Started</a> tutorial.</p>
     </div>

--- a/docs/tutorials/getting-started/creating-your-first-project.md
+++ b/docs/tutorials/getting-started/creating-your-first-project.md
@@ -20,7 +20,7 @@ Now you can use it to create a new project.
 
 ```bash
 # Create a project
-apostrophe create test-project
+apostrophe create-project test-project
 ```
 
 **Important: rather than `test-project`, use your own project's "short name" containing only letters, digits, hyphens and/or underscores. It will be used by default as a MongoDB database name and a basis for cookie names, etc.** (Hyphens seem more popular than underscores for such purposes.)


### PR DESCRIPTION
I wanted to check out 2.0 a bit more so I was following the tutorial and notice the `apostrophe create` command has been changed to `apostrophe create-project`, but wasn't reflected in the docs. I updated the two places I found, hopefully this helps!