### PR TITLE
Fixed code example typos.

### DIFF
--- a/docs/tutorials/getting-started/schema-guide.md
+++ b/docs/tutorials/getting-started/schema-guide.md
@@ -242,15 +242,15 @@ Example:
   label: 'Where will you be staying?',
   choices: [
     {
-      label: 'on-campus',
-      value: 'On Campus',
+      label: 'On Campus',
+      value: 'on-campus',
       showFields: [
         'accessible', 'vegetarian'
       ]
     },
     {
-      label: 'off-campus',
-      value: 'Off Campus'
+      label: 'Off Campus',
+      value: 'off-campus'
     }
   ]
 }


### PR DESCRIPTION
Label and value were switched in the code example.